### PR TITLE
Make schemas available in the packages output again

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -132,7 +132,7 @@
             default = packages.tf-ncl;
             inherit tf-ncl schema-merge;
             terraform = pkgs.terraform;
-          };
+          } // lib.mapAttrs' (name: value: lib.nameValuePair "schema-${name}" value) schemas;
 
           inherit terraformProviders;
 


### PR DESCRIPTION
Just using `inherit schemas` breaks `nix flake check` because the packages outputs are supposed to be derivations directly.