### PR TITLE
Use open records for certain special terraform blocks

### DIFF
--- a/schema-merge/intermediate.go
+++ b/schema-merge/intermediate.go
@@ -53,6 +53,7 @@ type Type struct {
 	MinItems *uint64               `json:"min,omitempty"`
 	MaxItems *uint64               `json:"max,omitempty"`
 	Content  *Type                 `json:"content,omitempty"`
+	Open     bool                  `json:"open,omitempty"`
 	Object   *map[string]Attribute `json:"object,omitempty"`
 }
 
@@ -60,6 +61,11 @@ type ListVariant struct {
 	MinItems *uint64 `json:"min,omitempty"`
 	MaxItems *uint64 `json:"max,omitempty"`
 	Content  *Type   `json:"content,omitempty"`
+}
+
+type ObjectVariant struct {
+	Open    bool                  `json:"open"`
+	Content *map[string]Attribute `json:"content,omitempty"`
 }
 
 func (t Type) MarshalJSON() (b []byte, e error) {
@@ -76,9 +82,12 @@ func (t Type) MarshalJSON() (b []byte, e error) {
 		})
 	case Object:
 		return json.Marshal(struct {
-			Object *map[string]Attribute
+			Object ObjectVariant
 		}{
-			Object: t.Object,
+			Object: ObjectVariant{
+				Open:    t.Open,
+				Content: t.Object,
+			},
 		})
 	case Dictionary:
 		return json.Marshal(struct {

--- a/tf-ncl/src/intermediate.rs
+++ b/tf-ncl/src/intermediate.rs
@@ -34,7 +34,10 @@ pub enum Type {
         max: Option<u32>,
         content: Box<Type>,
     },
-    Object(HashMap<String, Attribute>),
+    Object {
+        open: bool,
+        content: HashMap<String, Attribute>,
+    },
     #[serde(deserialize_with = "transparent")]
     Dictionary {
         inner: Box<Type>,
@@ -89,7 +92,7 @@ fn attribute_at_path<'a>(
     let mut obj = schema;
     for p in path.split_last().map(|x| x.1).unwrap_or(&[]) {
         obj = obj.get_mut(p).and_then(|attr| match &mut attr.type_ {
-            Type::Object(obj) => Some(obj),
+            Type::Object { open: _, content } => Some(content),
             _ => None,
         })?;
     }

--- a/tf-ncl/src/nickel.rs
+++ b/tf-ncl/src/nickel.rs
@@ -186,13 +186,14 @@ impl AsNickelContracts for &intermediate::Type {
                 ))),
                 None,
             ),
-            Object(fields) => (
+            Object { open, content } => (
                 Types(TypeF::Flat(
                     builder::Record::from(
-                        fields
+                        content
                             .iter()
                             .map(|(k, v)| v.as_nickel_field(builder::Field::name(k))),
                     )
+                    .set_open(*open)
                     .into(),
                 )),
                 None,

--- a/tf-ncl/src/nickel_builder.rs
+++ b/tf-ncl/src/nickel_builder.rs
@@ -260,6 +260,15 @@ impl Record {
         self
     }
 
+    #[allow(clippy::needless_update)]
+    pub fn set_open(mut self, o: bool) -> Self {
+        self.attrs = RecordAttrs {
+            open: o,
+            ..self.attrs
+        };
+        self
+    }
+
     pub fn build(self) -> RichTerm {
         let elaborated = self
             .fields

--- a/tf-ncl/src/nickel_builder.rs
+++ b/tf-ncl/src/nickel_builder.rs
@@ -261,9 +261,9 @@ impl Record {
     }
 
     #[allow(clippy::needless_update)]
-    pub fn set_open(mut self, o: bool) -> Self {
+    pub fn set_open(mut self, open: bool) -> Self {
         self.attrs = RecordAttrs {
-            open: o,
+            open,
             ..self.attrs
         };
         self

--- a/tf-ncl/src/nickel_builder.rs
+++ b/tf-ncl/src/nickel_builder.rs
@@ -251,6 +251,10 @@ impl Record {
         self
     }
 
+    // Clippy correctly observes that `open` is the only field in `RecordAttrs`.
+    // Nevertheless, we want to do the record update. That way we can be
+    // somewhat futureproof in case new fields are added to `RecordAttrs` in
+    // Nickel.
     #[allow(clippy::needless_update)]
     pub fn open(mut self) -> Self {
         self.attrs = RecordAttrs {
@@ -260,12 +264,10 @@ impl Record {
         self
     }
 
+    // See `open` for comments on the clippy directive
     #[allow(clippy::needless_update)]
     pub fn set_open(mut self, open: bool) -> Self {
-        self.attrs = RecordAttrs {
-            open,
-            ..self.attrs
-        };
+        self.attrs = RecordAttrs { open, ..self.attrs };
         self
     }
 


### PR DESCRIPTION
This should make it possible to use providers that don't have a schema contract yet; albeit without any special handling for computed fields. Additionally, this will facilitate applying multiple schema contracts instead of having to generate a single monolithic contract. For example, the following should work
```nickel
let Github = import "./github-schema.ncl" in
let Google = import "./google-schema.ncl" in
{
  config = {}
} | Github.Config | Google.Config
```
It doesn't, at the moment, because of a [Nickel quirk](https://github.com/tweag/nickel/issues/1228).