### PR TITLE
Update flake inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 [[package]]
 name = "nickel-lang"
 version = "0.3.1"
-source = "git+https://github.com/tweag/nickel#9275ac18dfba925f183015baaa3176c49f60d601"
+source = "git+https://github.com/tweag/nickel#c77cdcf03b5024bff4c31b5909239e8425e59e3a"
 dependencies = [
  "ansi_term",
  "codespan",

--- a/examples/github-users/lib.ncl
+++ b/examples/github-users/lib.ncl
@@ -1,7 +1,7 @@
 {
   uniq | Array Dyn -> Array Dyn =
       let go : { visited : { _ : {} }, out : Array Dyn } -> Dyn -> { visited : { _ : {} }, out : Array Dyn } = fun acc nxt =>
-          let as_str = std.serialize `Json nxt in
+          let as_str = std.serialize 'Json nxt in
           if std.record.has_field as_str acc.visited then
             acc
           else

--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         "topiary": "topiary"
       },
       "locked": {
-        "lastModified": 1682328457,
-        "narHash": "sha256-hFuFd89w7IZ2k2oONtJXlSW/1BKlFCoc6qc0wF+0YZc=",
+        "lastModified": 1682500406,
+        "narHash": "sha256-IGQCeiwbVjbg6DO9dW/wxETIJnXJ/MCL48GTyvwxoMw=",
         "owner": "tweag",
         "repo": "nickel",
-        "rev": "9275ac18dfba925f183015baaa3176c49f60d601",
+        "rev": "c77cdcf03b5024bff4c31b5909239e8425e59e3a",
         "type": "github"
       },
       "original": {
@@ -535,11 +535,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1682181988,
-        "narHash": "sha256-CYWhlNi16cjGzMby9h57gpYE59quBcsHPXiFgX4Sw5k=",
+        "lastModified": 1682453498,
+        "narHash": "sha256-WoWiAd7KZt5Eh6n+qojcivaVpnXKqBsVgpixpV2L9CE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c43a3495a11e261e5f41e5d7eda2d71dae1b2fe",
+        "rev": "c8018361fa1d1650ee8d4b96294783cf564e8a7f",
         "type": "github"
       },
       "original": {
@@ -781,11 +781,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682302828,
-        "narHash": "sha256-5uKDELNLWozRhv02ynzvGf8rx30b0m8DhPTT63IFVHo=",
+        "lastModified": 1682475596,
+        "narHash": "sha256-hQS8kPq5mSIhLZTRlCt1LHMBJtrOkWiXtvtizaU1e1Q=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "55de807250dd207007a0697e6e06d9fcba578d81",
+        "rev": "4d1bb70dd1231d0cd1d76deffe7bf0b6127185ea",
         "type": "github"
       },
       "original": {
@@ -868,11 +868,11 @@
         "rust-overlay": "rust-overlay_5"
       },
       "locked": {
-        "lastModified": 1680178226,
-        "narHash": "sha256-EZtmLYPQII8Ma9yH0udqlNjSXiYUg134j+0Srzb4rbM=",
+        "lastModified": 1682415064,
+        "narHash": "sha256-uAyg5d+i2YLJrY+nnoFb+w2wlcuwIa9Vs4UtvMEKBVs=",
         "owner": "tweag",
         "repo": "topiary",
-        "rev": "1af03d77abf6aef3ea36f878554c16619207252b",
+        "rev": "74952c7720ccd7f055f629b5cff61bda7adfab4f",
         "type": "github"
       },
       "original": {
@@ -891,11 +891,11 @@
         "rust-overlay": "rust-overlay_8"
       },
       "locked": {
-        "lastModified": 1682071041,
-        "narHash": "sha256-CkSjpGKUfmFkX7EWNgZFxIlewlgCQK9V3PJzfIKAIaQ=",
+        "lastModified": 1682503900,
+        "narHash": "sha256-3Kb9D8S0lkGcPAcpJJGInVyFN79K6gn6TN0ZHWFA19s=",
         "owner": "tweag",
         "repo": "topiary",
-        "rev": "a064b0ce19b654397e73457243f8fc2b4fc0a82c",
+        "rev": "773159aa4c819b46c6d51ca9275e7366087eb3a0",
         "type": "github"
       },
       "original": {

--- a/ncl/lib.ncl
+++ b/ncl/lib.ncl
@@ -1,13 +1,13 @@
 {
   deep_filter_map =
     {
-      go : Array String -> (Array String -> Dyn -> { action : [| `KeepStop, `Continue, `Delete |], value : Dyn }) -> { _ : Dyn } -> { _ : Dyn } -> String -> { _ : Dyn } = fun prefix f r acc field_name =>
+      go : Array String -> (Array String -> Dyn -> { action : [| 'KeepStop, 'Continue, 'Delete |], value : Dyn }) -> { _ : Dyn } -> { _ : Dyn } -> String -> { _ : Dyn } = fun prefix f r acc field_name =>
           let prefix = prefix @ [field_name] in
           let result = f prefix (r."%{field_name}") in
           result.action
           |> match {
-            `KeepStop => std.record.insert field_name result.value acc,
-            `Continue =>
+            'KeepStop => std.record.insert field_name result.value acc,
+            'Continue =>
               let new_value =
                 if std.is_record result.value then
                   (deep_filter_map_prefix prefix f (result.value | { _ : Dyn })) | Dyn
@@ -15,16 +15,16 @@
                   result.value
               in
               std.record.insert field_name new_value acc,
-            `Delete => acc,
+            'Delete => acc,
           },
 
-      deep_filter_map_prefix : Array String -> (Array String -> Dyn -> { action : [| `KeepStop, `Continue, `Delete |], value : Dyn }) -> { _ : Dyn } -> { _ : Dyn }
+      deep_filter_map_prefix : Array String -> (Array String -> Dyn -> { action : [| 'KeepStop, 'Continue, 'Delete |], value : Dyn }) -> { _ : Dyn } -> { _ : Dyn }
         = fun prefix f r =>
           r
           |> std.record.fields
           |> std.array.fold_left (go prefix f r) {},
 
-      deep_filter_map : (Array String -> Dyn -> { action : [| `KeepStop, `Continue, `Delete |], value : Dyn }) -> { _ : Dyn } -> { _ : Dyn }
+      deep_filter_map : (Array String -> Dyn -> { action : [| 'KeepStop, 'Continue, 'Delete |], value : Dyn }) -> { _ : Dyn } -> { _ : Dyn }
         = deep_filter_map_prefix [],
     }.deep_filter_map,
 
@@ -38,13 +38,13 @@
   TerraformField = fun ctr =>
     TaggedUnion
       "terraform_field_type"
-      [| `Undefined, `Literal, `Reference, `ProviderComputed |]
+      [| 'Undefined, 'Literal, 'Reference, 'ProviderComputed |]
       (
         match {
-          `Undefined => {},
-          `Literal => { value | ctr },
-          `Reference => { value | Array Dyn },
-          `ProviderComputed => { path | TerraformReference },
+          'Undefined => {},
+          'Literal => { value | ctr },
+          'Reference => { value | Array Dyn },
+          'ProviderComputed => { path | TerraformReference },
         }
       ),
 
@@ -56,24 +56,24 @@
     if is_terraform_field_record value_ then
       std.contract.apply (TerraformField ctr) label value_
     else
-      { terraform_field_type = `Literal, value | (fun _l v => std.contract.apply ctr label v) = value_ },
+      { terraform_field_type = 'Literal, value | (fun _l v => std.contract.apply ctr label v) = value_ },
 
   provider_computed = fun path_ =>
-    { terraform_field_type = `ProviderComputed, path = path_ },
+    { terraform_field_type = 'ProviderComputed, path = path_ },
 
-  undefined = { terraform_field_type | default = `Undefined },
+  undefined = { terraform_field_type | default = 'Undefined },
 
   resolve_reference : Array String -> String
     = fun ns => "${%{std.string.join "." ns}}",
 
-  typeof : Dyn -> [| `TerraformField, `Array, `Other |]
+  typeof : Dyn -> [| 'TerraformField, 'Array, 'Other |]
     = fun v =>
       if is_terraform_field_record v then
-        `TerraformField
+        'TerraformField
       else if std.is_array v then
-        `Array
+        'Array
       else
-        `Other,
+        'Other,
 
   resolve_provider_computed =
     let { go, resolve_field_action, .. } = {
@@ -81,43 +81,43 @@
         = fun path field =>
           field.terraform_field_type
           |> match {
-            `Undefined =>
+            'Undefined =>
               {
-                action = `Delete,
+                action = 'Delete,
                 value = null
               },
-            `Literal =>
+            'Literal =>
               {
-                action = `KeepStop,
+                action = 'KeepStop,
                 value = field.value
               },
-            `Reference =>
+            'Reference =>
               {
-                action = `KeepStop,
+                action = 'KeepStop,
                 value = resolve_reference field.value
               },
-            `ProviderComputed =>
+            'ProviderComputed =>
               if path == field.path then
-                { action = `Delete, value = null }
+                { action = 'Delete, value = null }
               else
                 {
-                  action = `KeepStop,
+                  action = 'KeepStop,
                   value = resolve_reference field.path
                 }
           },
-      go | Array String -> Dyn -> { action : [| `KeepStop, `Continue, `Delete |], value : Dyn }
+      go | Array String -> Dyn -> { action : [| 'KeepStop, 'Continue, 'Delete |], value : Dyn }
         = fun path field =>
           typeof field
           |> match {
-            `TerraformField => resolve_field_action path field,
-            `Array =>
+            'TerraformField => resolve_field_action path field,
+            'Array =>
               {
-                action = `KeepStop,
+                action = 'KeepStop,
                 value = std.array.map resolve_provider_computed field
               },
-            `Other =>
+            'Other =>
               {
-                action = `Continue,
+                action = 'Continue,
                 value = field
               }
           },
@@ -146,7 +146,7 @@
     in go,
 
   is_defined_terraform_field_record | Dyn -> Bool
-    = fun x => is_terraform_field_record x && x.terraform_field_type != `Undefined,
+    = fun x => is_terraform_field_record x && x.terraform_field_type != 'Undefined,
 
   has_defined_field | String -> { _ : Dyn } -> Bool
     = fun name r => std.record.has_field name r && is_defined_terraform_field_record r."%{name}",
@@ -164,19 +164,19 @@
         && has_defined_field_path (std.array.drop_first path) r."%{field}",
 
   FieldDescriptor = {
-    prio | [| `Default, `Force |],
+    prio | [| 'Default, 'Force |],
     path | Array String,
     ..
   },
 
   ElaboratedField = {
-    prio | [| `Default, `Force |],
+    prio | [| 'Default, 'Force |],
     path | Array String,
     record | { _ : Dyn },
   },
 
   mergeable | { _ : Dyn } -> FieldDescriptor -> Bool
-    = fun r field => !(has_defined_field_path field.path r && field.prio == `Default),
+    = fun r field => !(has_defined_field_path field.path r && field.prio == 'Default),
 
   elaborate_field | Array String -> { _ : Dyn } -> FieldDescriptor -> Array ElaboratedField
     =


### PR DESCRIPTION
This updates flake inputs to their latest versions. In particular, change enum tag syntax in `ncl/lib.ncl` and in the examples from `` `Foo `` to `'Foo`.